### PR TITLE
feat: Port UNI v4 Solidity Oracle Lib to Vyper

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -4,3 +4,4 @@ plugins:
     version: 0.8.8
 test:
   number_of_accounts: 50
+  log_level: DEBUG

--- a/contracts/oracle.vy
+++ b/contracts/oracle.vy
@@ -1,0 +1,640 @@
+# SPDX-License-Identifier: MIT
+# pragma version ~=0.4.0
+
+# --- Structs ---
+struct Observation:
+    block_timestamp: uint32
+    tick: int24  # Add tick to the observation
+    tick_cumulative: int56
+    seconds_per_liquidity_cumulative_x128: uint160
+    initialized: bool
+
+struct InitializeParams:
+    time: uint32
+    tick: int24
+    liquidity: uint128
+
+struct UpdateParams:
+    advance_time_by: uint32
+    tick: int24
+    liquidity: uint128
+
+# --- Events ---
+event ObservationUpdate:
+    block_timestamp: uint32
+    tick_cumulative: int56
+    seconds_per_liquidity_cumulative_x128: uint160
+    tick: int24
+    initialized: bool
+
+# --- Constants ---
+HALF_MAX_UINT32: constant(uint256) = 2147483648  # 0x80000000
+
+# --- Storage Variables ---
+observations: public(Observation[65535])
+time: public(uint32)
+tick: public(int24)
+liquidity: public(uint128)
+index: public(uint16)
+cardinality: public(uint16)
+cardinality_next: public(uint16)
+
+# --- Internal Helper Functions ---
+@internal
+@view
+def _lte(time: uint32, a: uint32, b: uint32) -> bool:
+    """
+    @notice Helper function to compare timestamps, accounting for uint32 overflow
+    @param time The timestamp to compare
+    @param a The first timestamp
+    @param b The second timestamp
+    @return True if a is less than or equal to b, false otherwise
+    """
+    if convert(a, uint256) < HALF_MAX_UINT32 and convert(b, uint256) < HALF_MAX_UINT32:
+        return a <= b
+    elif convert(a, uint256) >= HALF_MAX_UINT32 and convert(b, uint256) >= HALF_MAX_UINT32:
+        return a <= b
+    else:
+        return convert(a, uint256) >= HALF_MAX_UINT32
+
+@internal
+@pure
+def _transform(
+    last: Observation,
+    block_timestamp: uint32,
+    tick: int24,
+    liquidity: uint128
+) -> Observation:
+    # Handle uint32 overflow in timestamp arithmetic
+    delta: uint32 = 0
+    if block_timestamp < last.block_timestamp:
+        delta = convert(
+            (convert(block_timestamp, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(last.block_timestamp, uint256)),
+            uint32
+        )
+    else:
+        delta = block_timestamp - last.block_timestamp
+
+    # Calculate seconds_per_liquidity_cumulative_x128
+    seconds_shifted: uint256 = convert(delta, uint256) << 128
+    effective_liquidity: uint256 = convert(liquidity, uint256)
+    if effective_liquidity == 0:
+        effective_liquidity = 1
+    
+    seconds_per_liquidity_delta: uint256 = seconds_shifted // effective_liquidity
+    
+    # Handle uint160 overflow for seconds_per_liquidity_cumulative_x128
+    mask_160: uint256 = (1 << 160) - 1
+    new_seconds_per_liquidity_cumulative: uint160 = convert(
+        (convert(last.seconds_per_liquidity_cumulative_x128, uint256) + seconds_per_liquidity_delta) & mask_160,
+        uint160
+    )
+    
+    # Calculate tick_cumulative with wrapping
+    tick_delta: int56 = convert(last.tick, int56) * convert(delta, int56)
+    raw_sum: int256 = convert(last.tick_cumulative, int256) + convert(tick_delta, int256)
+    # Wrap around if necessary using modulo with int56 bounds
+    wrapped_sum: int256 = raw_sum % (1 << 55)
+    if raw_sum < 0 and wrapped_sum > 0:
+        wrapped_sum = wrapped_sum - (1 << 55)
+    
+    return Observation(
+        block_timestamp=block_timestamp,
+        tick=tick,
+        tick_cumulative=convert(wrapped_sum, int56),
+        seconds_per_liquidity_cumulative_x128=new_seconds_per_liquidity_cumulative,
+        initialized=True
+    )
+# @internal
+# @pure
+# def _transform(
+#     last: Observation,
+#     block_timestamp: uint32,
+#     tick: int24,
+#     liquidity: uint128
+# ) -> Observation:
+#     """
+#     @notice Transforms a previous observation into a new observation
+#     @param last The specified observation to be transformed
+#     @param block_timestamp The timestamp of the new observation
+#     @param tick The active tick at the time of the new observation
+#     @param liquidity The total in-range liquidity at the time of the new observation
+#     @return Observation The newly populated observation
+#     """
+#     # Handle uint32 overflow in timestamp arithmetic
+#     delta: uint32 = 0
+#     if block_timestamp < last.block_timestamp:
+#         # Handle overflow case
+#         delta = convert(
+#             (convert(block_timestamp, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(last.block_timestamp, uint256)),
+#             uint32
+#         )
+#     else:
+#         delta = block_timestamp - last.block_timestamp
+
+#     # Calculate seconds_per_liquidity_cumulative_x128
+#     seconds_shifted: uint256 = convert(delta, uint256) << 128
+#     effective_liquidity: uint256 = convert(liquidity, uint256)
+#     if effective_liquidity == 0:
+#         effective_liquidity = 1
+    
+#     seconds_per_liquidity_delta: uint256 = seconds_shifted // effective_liquidity
+    
+#     # Handle uint160 overflow for seconds_per_liquidity_cumulative_x128
+#     mask_160: uint256 = (1 << 160) - 1
+#     new_seconds_per_liquidity_cumulative: uint160 = convert(
+#         (convert(last.seconds_per_liquidity_cumulative_x128, uint256) + seconds_per_liquidity_delta) & mask_160,
+#         uint160
+#     )
+    
+#     return Observation(
+#         block_timestamp=block_timestamp,
+#         tick=tick,
+#         tick_cumulative=last.tick_cumulative + convert(last.tick, int56) * convert(delta, int56),
+#         seconds_per_liquidity_cumulative_x128=new_seconds_per_liquidity_cumulative,
+#         initialized=True
+#     )
+
+
+@internal
+def _write(
+    index: uint16,
+    block_timestamp: uint32,
+    tick: int24,
+    liquidity: uint128,
+    cardinality: uint16,
+    cardinality_next: uint16
+) -> (Observation, uint16, uint16):
+    """
+    @notice Writes a new observation, growing the observation array if necessary
+    @param index The index of the observation to write
+    @param block_timestamp The timestamp of the new observation
+    @param tick The active tick at the time of the new observation
+    @param liquidity The total in-range liquidity at the time of the new observation
+    @param cardinality The cardinality of the observation array
+    @param cardinality_next The cardinality of the next observation
+    @return The new observation, the index of the updated observation and the cardinality of the observation array
+    """
+    if self.observations[index].block_timestamp == block_timestamp:
+        return self.observations[index], index, cardinality
+
+    
+    
+    # # If we can grow and haven't filled the current cardinality, grow
+    # new_cardinality: uint16 = cardinality
+    # if cardinality_next > cardinality and index_updated < cardinality_next:
+    #     new_cardinality = cardinality_next
+    # else:
+    #     # Only wrap if we're not growing
+    #     if index_updated >= cardinality:
+    #         index_updated = 0
+    # If we can grow and haven't filled the current cardinality, grow
+    new_cardinality: uint16 = cardinality
+    if cardinality_next > cardinality and index == (cardinality - 1):
+        new_cardinality = cardinality_next
+    else:
+        new_cardinality = cardinality
+        # # Only wrap if we're not growing
+        # if index_updated >= cardinality:
+        #     index_updated = 0
+
+    # Calculate next index with proper wrapping
+    index_updated: uint16 = (index + 1) % new_cardinality
+    
+    new_observation: Observation = self._transform(
+        self.observations[index],
+        block_timestamp,
+        tick,
+        self.liquidity  # Pass current liquidity instead of new liquidity
+    )
+    
+    self.observations[index_updated] = new_observation
+    log ObservationUpdate(
+        new_observation.block_timestamp,
+        new_observation.tick_cumulative,
+        new_observation.seconds_per_liquidity_cumulative_x128,
+        new_observation.tick,
+        new_observation.initialized
+    )
+    return new_observation, index_updated, new_cardinality
+
+@internal
+def _grow(current: uint16, next: uint16) -> uint16:
+    """
+    @notice Grows the observation array to the desired size
+    @param current The current next cardinality of the oracle array
+    @param next The proposed next cardinality which will be populated in the oracle array
+    @return next The next cardinality which will be populated in the oracle array
+    """
+    assert current != 0, "oracle cardinality cannot be zero"
+
+    # no-op if the passed next value isn't greater than the current value
+    if next <= current:
+        return current
+        
+    # store in each slot to prevent fresh SSTOREs in swaps
+    # this data will not be used because the initialized boolean is still false
+    for i: uint16 in range(65535):
+        if i < current:
+            continue
+        if i >= next:
+            break
+        self.observations[i].block_timestamp = 1
+        
+    return next
+
+@internal
+@view
+def _binary_search(
+    time: uint32,
+    target: uint32,
+    index: uint16,
+    cardinality: uint16
+) -> (Observation, Observation, uint16):
+    """
+    @notice Performs a binary search to find the surrounding observations
+    @param time The timestamp to search for
+    @param target The target timestamp
+    @param index The index of the observation to search from
+    @param cardinality The cardinality of the observation array
+    @return The surrounding observations and the target index
+    """
+    # Convert to uint256 to avoid underflow issues
+    left: uint256 = convert((index + 1) % cardinality, uint256)  # oldest observation
+    right: uint256 = left + convert(cardinality, uint256) - 1  # newest observation
+    
+    # Initialize return values
+    before_or_at: Observation = empty(Observation)
+    at_or_after: Observation = empty(Observation)
+    target_index: uint16 = 0
+    
+    # Use range-based iteration with a maximum number of iterations based on max possible cardinality
+    # log2(65535) ≈ 16, so 20 iterations is more than enough
+    for i: uint256 in range(20):
+        if left > right:
+            break
+            
+        current: uint256 = (left + right) // 2
+        current_index: uint16 = convert(current % convert(cardinality, uint256), uint16)
+        before_or_at = self.observations[current_index]
+            
+        if not before_or_at.initialized:
+            left = current + 1
+            continue
+            
+        next_index: uint16 = convert((current + 1) % convert(cardinality, uint256), uint16)
+        at_or_after = self.observations[next_index]
+
+        if self._lte(time, before_or_at.block_timestamp, target):
+            if self._lte(time, target, at_or_after.block_timestamp):
+                target_index = current_index
+                return before_or_at, at_or_after, target_index
+            left = current + 1
+        else:
+            right = current - 1
+    
+    # If we haven't found a valid observation, revert
+    assert False, "binary search failed"
+    return empty(Observation), empty(Observation), 0  # Unreachable but needed for compilation
+
+@internal
+@view
+def _get_surrounding_observations(
+    time: uint32,
+    target: uint32,
+    tick: int24,
+    index: uint16,
+    liquidity: uint128,
+    cardinality: uint16
+) -> (Observation, Observation, bool):
+    """
+    @notice Gets the observations surrounding a target timestamp
+    @param time The current block.timestamp
+    @param target The target timestamp to find observations around
+    @param tick The current tick
+    @param index The index of the latest observation
+    @param liquidity The current in-range liquidity
+    @param cardinality The number of populated observations
+    @return The surrounding observations and whether the target is counterfactual
+    """
+    before_or_at: Observation = self.observations[index]
+    at_or_after: Observation = empty(Observation)
+    is_counterfactual: bool = False
+
+    # Check if we're at or beyond the latest observation
+    if self._lte(time, before_or_at.block_timestamp, target):
+        if before_or_at.block_timestamp == target:
+            return before_or_at, at_or_after, is_counterfactual
+        else:
+            # Need to transform the latest observation to the target timestamp
+            at_or_after = self._transform(
+                before_or_at,
+                target + 1,
+                tick,
+                liquidity
+            )
+            is_counterfactual = True
+            return before_or_at, at_or_after, is_counterfactual
+
+    # Get the oldest observation
+    oldest_index: uint16 = (index + 1) % cardinality
+    before_or_at = self.observations[oldest_index]
+    if not before_or_at.initialized:
+        before_or_at = self.observations[0]
+
+    assert self._lte(time, before_or_at.block_timestamp, target), "target predates oldest observation"
+
+    # Find the observations around target
+    search_before_or_at: Observation = empty(Observation)
+    search_at_or_after: Observation = empty(Observation)
+    target_index: uint16 = 0
+    search_before_or_at, search_at_or_after, target_index = self._binary_search(
+        time,
+        target,
+        index,
+        cardinality
+    )
+
+    before_or_at = search_before_or_at
+    at_or_after = search_at_or_after
+
+    if before_or_at.block_timestamp == target:
+        if target_index == (cardinality - 1):
+            at_or_after = self.observations[0]
+        else:
+            at_or_after = self.observations[target_index + 1]
+    elif at_or_after.block_timestamp == target:
+        before_or_at = self.observations[target_index - 1]
+    else:
+        # If we don't have a valid at_or_after observation, transform the before_or_at
+        if not at_or_after.initialized:
+            at_or_after = self._transform(
+                before_or_at,
+                target + 1,
+                tick,
+                liquidity
+            )
+            is_counterfactual = True
+
+    return before_or_at, at_or_after, is_counterfactual
+
+@internal
+@view
+def _observe_single(
+    time: uint32,
+    seconds_ago: uint32,
+    tick: int24,
+    index: uint16,
+    liquidity: uint128,
+    cardinality: uint16
+) -> (int56, uint160):
+    assert seconds_ago <= time, "seconds_ago is greater than time"  # Add this check
+    target: uint32 = time - seconds_ago
+
+    before_or_at: Observation = empty(Observation)
+    at_or_after: Observation = empty(Observation)
+    is_counterfactual: bool = False
+    before_or_at, at_or_after, is_counterfactual = self._get_surrounding_observations(
+        time,
+        target,
+        tick,
+        index,
+        liquidity,
+        cardinality
+    )
+
+    if target == before_or_at.block_timestamp:
+        return before_or_at.tick_cumulative, before_or_at.seconds_per_liquidity_cumulative_x128
+    elif target == at_or_after.block_timestamp:
+        return at_or_after.tick_cumulative, at_or_after.seconds_per_liquidity_cumulative_x128
+    else:
+        # Handle uint32 overflow in timestamp arithmetic
+        observation_time_delta: uint32 = 0
+        if at_or_after.block_timestamp < before_or_at.block_timestamp:
+            # Handle overflow case
+            observation_time_delta = convert(
+                (convert(at_or_after.block_timestamp, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(before_or_at.block_timestamp, uint256)),
+                uint32
+            )
+        else:
+            observation_time_delta = at_or_after.block_timestamp - before_or_at.block_timestamp
+
+        target_delta: uint32 = 0
+        if target < before_or_at.block_timestamp:
+            # Handle overflow case
+            target_delta = convert(
+                (convert(target, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(before_or_at.block_timestamp, uint256)),
+                uint32
+            )
+        else:
+            target_delta = target - before_or_at.block_timestamp
+
+        if is_counterfactual:
+            # For counterfactual, use the stored tick to calculate accumulation
+            tick_cumulative: int56 = before_or_at.tick_cumulative + convert(before_or_at.tick, int56) * convert(target_delta, int56)
+            # Calculate seconds per liquidity for counterfactual case
+            seconds_shifted: uint256 = convert(target_delta, uint256) << 128
+            effective_liquidity: uint256 = convert(liquidity, uint256)
+            if effective_liquidity == 0:
+                effective_liquidity = 1
+            seconds_per_liquidity_delta: uint256 = seconds_shifted // effective_liquidity
+            seconds_per_liquidity_cumulative_x128: uint160 = convert(
+                convert(before_or_at.seconds_per_liquidity_cumulative_x128, uint256) + seconds_per_liquidity_delta,
+                uint160
+            )
+            return tick_cumulative, seconds_per_liquidity_cumulative_x128
+        else:
+            # For real observations, interpolate between the points
+            tick_delta: int56 = at_or_after.tick_cumulative - before_or_at.tick_cumulative
+            tick_cumulative: int56 = before_or_at.tick_cumulative + (tick_delta * convert(target_delta, int56)) // convert(observation_time_delta, int56)
+            
+            seconds_per_liquidity_delta: uint256 = convert(
+                at_or_after.seconds_per_liquidity_cumulative_x128 - before_or_at.seconds_per_liquidity_cumulative_x128,
+                uint256
+            )
+            seconds_per_liquidity_cumulative_x128: uint160 = convert(
+                convert(before_or_at.seconds_per_liquidity_cumulative_x128, uint256) + 
+                (seconds_per_liquidity_delta * convert(target_delta, uint256)) // convert(observation_time_delta, uint256),
+                uint160
+            )
+            return tick_cumulative, seconds_per_liquidity_cumulative_x128
+
+# --- External Functions ---
+@external
+def initialize(params: InitializeParams):
+    """
+    @notice Initialize the oracle with the first observation
+    @param params The initialization parameters
+    """
+    assert self.cardinality == 0, "already initialized"
+    
+    # Set initial state
+    self.time = params.time
+    self.tick = params.tick
+    self.liquidity = params.liquidity
+    
+    # Create and store first observation
+    new_observation: Observation = Observation(
+        block_timestamp=params.time,
+        tick=params.tick,  # Store the initial tick
+        tick_cumulative=0,
+        seconds_per_liquidity_cumulative_x128=0,
+        initialized=True
+    )
+    
+    self.observations[0] = new_observation
+    self.cardinality = 1
+    self.cardinality_next = 1
+    
+    # Log the initialization
+    log ObservationUpdate(
+        new_observation.block_timestamp,
+        new_observation.tick_cumulative,
+        new_observation.seconds_per_liquidity_cumulative_x128,
+        new_observation.tick,
+        new_observation.initialized
+    )
+
+@external
+def advance_time(by: uint32):
+    """
+    @notice Advance the oracle time by a specified amount
+    @param by The amount of time to advance by
+    """
+    self.time = unsafe_add(self.time, by)
+
+@external
+def update(params: UpdateParams):
+    """
+    @notice Update the oracle with new observations
+    @param params The update parameters
+    """
+    self.time = unsafe_add(self.time, params.advance_time_by)
+    old_index: uint16 = self.index
+    new_observation: Observation = empty(Observation)
+    next_index: uint16 = 0
+    new_cardinality: uint16 = 0
+    new_observation, next_index, new_cardinality = self._write(
+        old_index,
+        self.time,
+        params.tick,  # Pass the new tick
+        params.liquidity,
+        self.cardinality,
+        self.cardinality_next
+    )
+    self.index = next_index
+    self.cardinality = new_cardinality
+    self.tick = params.tick
+    self.liquidity = params.liquidity
+
+@external
+def batch_update(params: DynArray[UpdateParams, 300]):
+    """
+    @notice Update the oracle with multiple observations in a batch
+    @param params Array of update parameters
+    """
+    _tick: int24 = self.tick
+    _liquidity: uint128 = self.liquidity
+    _index: uint16 = self.index
+    _cardinality: uint16 = self.cardinality
+    _cardinality_next: uint16 = self.cardinality_next
+    _time: uint32 = self.time
+    params_length: uint256 = len(params)
+
+    for i: uint256 in range(300):
+        if i >= params_length:
+            break
+        _time = unsafe_add(_time, params[i].advance_time_by)
+        new_observation: Observation = empty(Observation)
+        new_observation, _index, _cardinality = self._write(
+            _index,
+            _time,
+            _tick,
+            _liquidity,
+            _cardinality,
+            _cardinality_next
+        )
+        _tick = params[i].tick
+        _liquidity = params[i].liquidity
+
+    self.tick = _tick
+    self.liquidity = _liquidity
+    self.index = _index
+    self.cardinality = _cardinality
+    self.time = _time
+
+@external
+def grow(_cardinality_next: uint16):
+    """
+    @notice Grow the oracle's observation array to a larger size
+    @param _cardinality_next The new desired size of the array
+    """
+    self.cardinality_next = self._grow(self.cardinality_next, _cardinality_next)
+
+@external
+@view
+def observe(seconds_agos: DynArray[uint32, 256]) -> (DynArray[int56, 256], DynArray[uint160, 256]):
+    """
+    @notice Get observations from specified seconds ago
+    @param seconds_agos Array of seconds ago to query
+    @return Arrays of tick cumulatives and seconds per liquidity cumulatives
+    """
+    assert self.cardinality > 0, "oracle cardinality cannot be zero"
+    tick_cumulatives: DynArray[int56, 256] = []
+    seconds_per_liquidity_cumulative_x128s: DynArray[uint160, 256] = []
+    
+    seconds_agos_length: uint256 = len(seconds_agos)
+    
+    for i: uint256 in range(256):
+        if i >= seconds_agos_length:
+            break
+            
+        tick_cumulative: int56 = 0
+        seconds_per_liquidity_cumulative_x128: uint160 = 0
+        tick_cumulative, seconds_per_liquidity_cumulative_x128 = self._observe_single(
+            self.time,
+            seconds_agos[i],
+            self.tick,
+            self.index,
+            self.liquidity,
+            self.cardinality
+        )
+        tick_cumulatives.append(tick_cumulative)
+        seconds_per_liquidity_cumulative_x128s.append(seconds_per_liquidity_cumulative_x128)
+
+    return tick_cumulatives, seconds_per_liquidity_cumulative_x128s
+
+@external
+@view
+def get_gas_cost_of_observe(seconds_agos: DynArray[uint32, 256]) -> uint256:
+    """
+    @notice Calculate the gas cost of an observe operation
+    @param seconds_agos Array of seconds ago to query
+    @return The gas cost
+    """
+    gas_before: uint256 = msg.gas
+    
+    # Implement observation logic directly instead of calling self.observe
+    tick_cumulatives: DynArray[int56, 256] = []
+    seconds_per_liquidity_cumulative_x128s: DynArray[uint160, 256] = []
+    
+    seconds_agos_length: uint256 = len(seconds_agos)
+    
+    for i: uint256 in range(256):
+        if i >= seconds_agos_length:
+            break
+            
+        tick_cumulative: int56 = 0
+        seconds_per_liquidity_cumulative_x128: uint160 = 0
+        tick_cumulative, seconds_per_liquidity_cumulative_x128 = self._observe_single(
+            self.time,
+            seconds_agos[i],
+            self.tick,
+            self.index,
+            self.liquidity,
+            self.cardinality
+        )
+        tick_cumulatives.append(tick_cumulative)
+        seconds_per_liquidity_cumulative_x128s.append(seconds_per_liquidity_cumulative_x128)
+    
+    return unsafe_sub(gas_before, msg.gas)

--- a/contracts/oracle.vy
+++ b/contracts/oracle.vy
@@ -105,56 +105,6 @@ def _transform(
         seconds_per_liquidity_cumulative_x128=new_seconds_per_liquidity_cumulative,
         initialized=True
     )
-# @internal
-# @pure
-# def _transform(
-#     last: Observation,
-#     block_timestamp: uint32,
-#     tick: int24,
-#     liquidity: uint128
-# ) -> Observation:
-#     """
-#     @notice Transforms a previous observation into a new observation
-#     @param last The specified observation to be transformed
-#     @param block_timestamp The timestamp of the new observation
-#     @param tick The active tick at the time of the new observation
-#     @param liquidity The total in-range liquidity at the time of the new observation
-#     @return Observation The newly populated observation
-#     """
-#     # Handle uint32 overflow in timestamp arithmetic
-#     delta: uint32 = 0
-#     if block_timestamp < last.block_timestamp:
-#         # Handle overflow case
-#         delta = convert(
-#             (convert(block_timestamp, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(last.block_timestamp, uint256)),
-#             uint32
-#         )
-#     else:
-#         delta = block_timestamp - last.block_timestamp
-
-#     # Calculate seconds_per_liquidity_cumulative_x128
-#     seconds_shifted: uint256 = convert(delta, uint256) << 128
-#     effective_liquidity: uint256 = convert(liquidity, uint256)
-#     if effective_liquidity == 0:
-#         effective_liquidity = 1
-    
-#     seconds_per_liquidity_delta: uint256 = seconds_shifted // effective_liquidity
-    
-#     # Handle uint160 overflow for seconds_per_liquidity_cumulative_x128
-#     mask_160: uint256 = (1 << 160) - 1
-#     new_seconds_per_liquidity_cumulative: uint160 = convert(
-#         (convert(last.seconds_per_liquidity_cumulative_x128, uint256) + seconds_per_liquidity_delta) & mask_160,
-#         uint160
-#     )
-    
-#     return Observation(
-#         block_timestamp=block_timestamp,
-#         tick=tick,
-#         tick_cumulative=last.tick_cumulative + convert(last.tick, int56) * convert(delta, int56),
-#         seconds_per_liquidity_cumulative_x128=new_seconds_per_liquidity_cumulative,
-#         initialized=True
-#     )
-
 
 @internal
 def _write(
@@ -178,25 +128,11 @@ def _write(
     if self.observations[index].block_timestamp == block_timestamp:
         return self.observations[index], index, cardinality
 
-    
-    
-    # # If we can grow and haven't filled the current cardinality, grow
-    # new_cardinality: uint16 = cardinality
-    # if cardinality_next > cardinality and index_updated < cardinality_next:
-    #     new_cardinality = cardinality_next
-    # else:
-    #     # Only wrap if we're not growing
-    #     if index_updated >= cardinality:
-    #         index_updated = 0
-    # If we can grow and haven't filled the current cardinality, grow
     new_cardinality: uint16 = cardinality
     if cardinality_next > cardinality and index == (cardinality - 1):
         new_cardinality = cardinality_next
     else:
         new_cardinality = cardinality
-        # # Only wrap if we're not growing
-        # if index_updated >= cardinality:
-        #     index_updated = 0
 
     # Calculate next index with proper wrapping
     index_updated: uint16 = (index + 1) % new_cardinality

--- a/contracts/oracle_full.vy
+++ b/contracts/oracle_full.vy
@@ -1,0 +1,637 @@
+# SPDX-License-Identifier: MIT
+# pragma version ~=0.4.0
+
+# --- Structs ---
+struct Observation:
+    block_timestamp: uint32
+    tick: int24  # Add tick to the observation
+    tick_cumulative: int56
+    seconds_per_liquidity_cumulative_x128: uint160
+    initialized: bool
+
+struct InitializeParams:
+    time: uint32
+    tick: int24
+    liquidity: uint128
+
+struct UpdateParams:
+    advance_time_by: uint32
+    tick: int24
+    liquidity: uint128
+
+# --- Events ---
+event ObservationUpdate:
+    block_timestamp: uint32
+    tick_cumulative: int56
+    seconds_per_liquidity_cumulative_x128: uint160
+    tick: int24
+    initialized: bool
+
+# --- Constants ---
+HALF_MAX_UINT32: constant(uint256) = 2147483648  # 0x80000000
+
+# --- Storage Variables ---
+observations: public(Observation[65535])
+time: public(uint32)
+tick: public(int24)
+liquidity: public(uint128)
+index: public(uint16)
+cardinality: public(uint16)
+cardinality_next: public(uint16)
+
+# --- Internal Helper Functions ---
+@internal
+@view
+def _lte(time: uint32, a: uint32, b: uint32) -> bool:
+    """
+    @notice Helper function to compare timestamps, accounting for uint32 overflow
+    @param time The timestamp to compare
+    @param a The first timestamp
+    @param b The second timestamp
+    @return True if a is less than or equal to b, false otherwise
+    """
+    if convert(a, uint256) < HALF_MAX_UINT32 and convert(b, uint256) < HALF_MAX_UINT32:
+        return a <= b
+    elif convert(a, uint256) >= HALF_MAX_UINT32 and convert(b, uint256) >= HALF_MAX_UINT32:
+        return a <= b
+    else:
+        return convert(a, uint256) >= HALF_MAX_UINT32
+
+@view
+@internal
+def _transform(last: Observation, block_timestamp: uint32, tick: int24, liquidity: uint128) -> Observation:
+
+    delta: uint32 = block_timestamp - last.block_timestamp
+    if block_timestamp < last.block_timestamp:
+        delta = convert(
+            (convert(block_timestamp, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(last.block_timestamp, uint256)),
+            uint32
+        )
+
+    seconds_per_liquidity_x128: uint160 = last.seconds_per_liquidity_cumulative_x128
+    delta_256: uint256 = convert(delta, uint256)
+    shifted: uint256 = delta_256 << 128
+
+    # Handle zero liquidity case
+    liquidity_256: uint256 = 0
+    if liquidity > 0:
+        liquidity_256 = convert(liquidity, uint256)
+    else:
+        liquidity_256 = 1
+
+    result: uint256 = shifted // liquidity_256
+    contribution: uint160 = convert(result, uint160)
+    
+    # Add contribution unless it's the very first observation
+    if last.initialized:
+        seconds_per_liquidity_x128 = unsafe_add(
+            seconds_per_liquidity_x128,
+            contribution
+        )
+
+    tick_delta: int56 = convert(tick, int56) * convert(delta, int56)
+    new_tick_cumulative: int56 = last.tick_cumulative + tick_delta
+
+    return Observation({
+        block_timestamp: unsafe_add(last.block_timestamp, delta),
+        tick: tick,
+        tick_cumulative: new_tick_cumulative,
+        seconds_per_liquidity_cumulative_x128: seconds_per_liquidity_x128,
+        initialized: True
+    })
+
+@internal
+def _write(
+    index: uint16,
+    block_timestamp: uint32,
+    tick: int24,
+    liquidity: uint128,
+    cardinality: uint16,
+    cardinality_next: uint16
+) -> (Observation, uint16, uint16):
+    
+    # log Debug(debug_str)
+    # print(debug_str)
+    """
+    @notice Writes a new observation, growing the observation array if necessary
+    @param index The index of the observation to write
+    @param block_timestamp The timestamp of the new observation
+    @param tick The active tick at the time of the new observation
+    @param liquidity The total in-range liquidity at the time of the new observation
+    @param cardinality The cardinality of the observation array
+    @param cardinality_next The cardinality of the next observation
+    @return The new observation, the index of the updated observation and the cardinality of the observation array
+    """
+    self.liquidity = liquidity
+
+    if self.observations[index].block_timestamp == block_timestamp:
+        return self.observations[index], index, cardinality
+
+    new_cardinality: uint16 = cardinality
+    if cardinality_next > cardinality and index == (cardinality - 1):
+        new_cardinality = cardinality_next
+    else:
+        new_cardinality = cardinality
+
+    # Calculate next index with proper wrapping
+    index_updated: uint16 = (index + 1) % new_cardinality
+
+    new_observation: Observation = self._transform(
+        self.observations[index],
+        block_timestamp,
+        tick,
+        self.liquidity  # Pass current liquidity instead of new liquidity
+    )
+
+    self.observations[index_updated] = new_observation
+    log ObservationUpdate(
+        new_observation.block_timestamp,
+        new_observation.tick_cumulative,
+        new_observation.seconds_per_liquidity_cumulative_x128,
+        new_observation.tick,
+        new_observation.initialized
+    )
+    return new_observation, index_updated, new_cardinality
+
+@internal
+def _grow(current: uint16, next: uint16) -> uint16:
+    """
+    @notice Grows the observation array to the desired size
+    @param current The current next cardinality of the oracle array
+    @param next The proposed next cardinality which will be populated in the oracle array
+    @return next The next cardinality which will be populated in the oracle array
+    """
+    assert current != 0, "oracle cardinality cannot be zero"
+
+    # no-op if the passed next value isn't greater than the current value
+    if next <= current:
+        return current
+        
+    # store in each slot to prevent fresh SSTOREs in swaps
+    # this data will not be used because the initialized boolean is still false
+    for i: uint16 in range(65535):
+        if i < current:
+            continue
+        if i >= next:
+            break
+        self.observations[i].block_timestamp = 1
+        
+    return next
+
+@internal
+@view
+def _binary_search(
+    time: uint32,
+    target: uint32,
+    index: uint16,
+    cardinality: uint16
+) -> (Observation, Observation, uint16):
+    """
+    @notice Performs a binary search to find the surrounding observations
+    @param time The timestamp to search for
+    @param target The target timestamp
+    @param index The index of the observation to search from
+    @param cardinality The cardinality of the observation array
+    @return The surrounding observations and the target index
+    """
+    # Convert to uint256 to avoid underflow issues
+    left: uint256 = convert((index + 1) % cardinality, uint256)  # oldest observation
+    right: uint256 = left + convert(cardinality, uint256) - 1  # newest observation
+    
+    # Initialize return values
+    before_or_at: Observation = empty(Observation)
+    at_or_after: Observation = empty(Observation)
+    target_index: uint16 = 0
+    
+    # Use range-based iteration with a maximum number of iterations based on max possible cardinality
+    # log2(65535) ≈ 16, so 20 iterations is more than enough
+    for i: uint256 in range(20):
+        if left > right:
+            break
+            
+        current: uint256 = (left + right) // 2
+        current_index: uint16 = convert(current % convert(cardinality, uint256), uint16)
+        before_or_at = self.observations[current_index]
+            
+        if not before_or_at.initialized:
+            left = current + 1
+            continue
+            
+        next_index: uint16 = convert((current + 1) % convert(cardinality, uint256), uint16)
+        at_or_after = self.observations[next_index]
+
+        if self._lte(time, before_or_at.block_timestamp, target):
+            if self._lte(time, target, at_or_after.block_timestamp):
+                target_index = current_index
+                return before_or_at, at_or_after, target_index
+            left = current + 1
+        else:
+            right = current - 1
+    
+    # If we haven't found a valid observation, revert
+    assert False, "binary search failed"
+    return empty(Observation), empty(Observation), 0  # Unreachable but needed for compilation
+
+@internal
+@view
+def _get_surrounding_observations(
+    time: uint32,
+    target: uint32,
+    tick: int24,
+    index: uint16,
+    liquidity: uint128,
+    cardinality: uint16
+) -> (Observation, Observation, bool):
+    """
+    @notice Gets the observations surrounding a target timestamp
+    @param time The current block.timestamp
+    @param target The target timestamp to find observations around
+    @param tick The current tick
+    @param index The index of the latest observation
+    @param liquidity The current in-range liquidity
+    @param cardinality The number of populated observations
+    @return The surrounding observations and whether the target is counterfactual
+    """
+    before_or_at: Observation = self.observations[index]
+    at_or_after: Observation = empty(Observation)
+    is_counterfactual: bool = False
+
+    # Check if we're at or beyond the latest observation
+    if self._lte(time, before_or_at.block_timestamp, target):
+        if before_or_at.block_timestamp == target:
+            # Get the next observation for interpolation
+            if index == 0:
+                at_or_after = self.observations[cardinality - 1]
+            else:
+                at_or_after = self.observations[index - 1]
+            if not at_or_after.initialized:
+                # If next observation isn't initialized, transform the current one
+                at_or_after = self._transform(
+                    before_or_at,
+                    target + 1,
+                    tick,
+                    liquidity
+                )
+                is_counterfactual = True
+            return before_or_at, at_or_after, is_counterfactual
+        else:
+            # Need to transform the latest observation to the target timestamp
+            at_or_after = self._transform(
+                before_or_at,
+                target + 1,
+                tick,
+                liquidity
+            )
+            is_counterfactual = True
+            return before_or_at, at_or_after, is_counterfactual
+
+    # Get the oldest observation
+    oldest_index: uint16 = (index + 1) % cardinality
+    before_or_at = self.observations[oldest_index]
+    if not before_or_at.initialized:
+        before_or_at = self.observations[0]
+
+    assert self._lte(time, before_or_at.block_timestamp, target), "target predates oldest observation"
+
+    # Find the observations around target
+    search_before_or_at: Observation = empty(Observation)
+    search_at_or_after: Observation = empty(Observation)
+    target_index: uint16 = 0
+    search_before_or_at, search_at_or_after, target_index = self._binary_search(
+        time,
+        target,
+        index,
+        cardinality
+    )
+
+    before_or_at = search_before_or_at
+    at_or_after = search_at_or_after
+
+    if before_or_at.block_timestamp == target:
+        if target_index == (cardinality - 1):
+            at_or_after = self.observations[0]
+        else:
+            at_or_after = self.observations[target_index + 1]
+        if not at_or_after.initialized:
+            # If next observation isn't initialized, transform the current one
+            at_or_after = self._transform(
+                before_or_at,
+                target + 1,
+                tick,
+                liquidity
+            )
+            is_counterfactual = True
+    elif at_or_after.block_timestamp == target:
+        before_or_at = self.observations[target_index - 1]
+    else:
+        # If we don't have a valid at_or_after observation, transform the before_or_at
+        if not at_or_after.initialized:
+            at_or_after = self._transform(
+                before_or_at,
+                target + 1,
+                tick,
+                liquidity
+            )
+            is_counterfactual = True
+
+    return before_or_at, at_or_after, is_counterfactual
+
+@internal
+@view
+def _observe_single(
+    time: uint32,
+    seconds_ago: uint32,
+    tick: int24,
+    index: uint16,
+    liquidity: uint128,
+    cardinality: uint16
+) -> (int56, uint160):
+    print("Input - time:", time)
+    print("Input - seconds_ago:", seconds_ago)
+    print("Input - tick:", tick)
+    print("Input - liquidity:", liquidity)
+
+    assert seconds_ago <= time, "seconds_ago is greater than time"
+    target: uint32 = time - seconds_ago
+    print("Target time:", target)
+
+    before_or_at: Observation = empty(Observation)
+    at_or_after: Observation = empty(Observation)
+    is_counterfactual: bool = False
+    before_or_at, at_or_after, is_counterfactual = self._get_surrounding_observations(
+        time,
+        target,
+        tick,
+        index,
+        liquidity,
+        cardinality
+    )
+
+    print("Before observation - timestamp:", before_or_at.block_timestamp)
+    print("Before observation - tick_cumulative:", before_or_at.tick_cumulative)
+    print("Before observation - seconds_per_liquidity:", before_or_at.seconds_per_liquidity_cumulative_x128)
+    
+    print("After observation - timestamp:", at_or_after.block_timestamp)
+    print("After observation - tick_cumulative:", at_or_after.tick_cumulative)
+    print("After observation - seconds_per_liquidity:", at_or_after.seconds_per_liquidity_cumulative_x128)
+    
+    print("Is counterfactual:", is_counterfactual)
+
+    if target == before_or_at.block_timestamp:
+        print("Exact match with before_or_at")
+        return before_or_at.tick_cumulative, before_or_at.seconds_per_liquidity_cumulative_x128
+    else:
+        print("Interpolating between observations")
+        
+        # Handle uint32 overflow in timestamp arithmetic
+        observation_time_delta: uint32 = 0
+        if at_or_after.block_timestamp < before_or_at.block_timestamp:
+            observation_time_delta = convert(
+                (convert(at_or_after.block_timestamp, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(before_or_at.block_timestamp, uint256)),
+                uint32
+            )
+        else:
+            observation_time_delta = at_or_after.block_timestamp - before_or_at.block_timestamp
+
+        target_delta: uint32 = 0
+        if target < before_or_at.block_timestamp:
+            target_delta = convert(
+                (convert(target, uint256) + convert(max_value(uint32), uint256) + convert(1, uint256) - convert(before_or_at.block_timestamp, uint256)),
+                uint32
+            )
+        else:
+            target_delta = target - before_or_at.block_timestamp
+
+        print("Interpolation - target_delta:", target_delta)
+        print("Interpolation - time_delta:", observation_time_delta)
+
+        if is_counterfactual:
+            # For counterfactual observations, use the current tick and liquidity
+            tick_cumulative: int56 = before_or_at.tick_cumulative + convert(tick, int56) * convert(target_delta, int56)
+            
+            # Calculate seconds per liquidity for counterfactual case
+            target_delta_scaled: uint256 = convert(target_delta, uint256) << 128
+            effective_liquidity: uint256 = convert(liquidity, uint256)
+            if effective_liquidity == 0:
+                effective_liquidity = 1
+            
+            seconds_per_liquidity_delta: uint256 = target_delta_scaled // effective_liquidity
+            seconds_per_liquidity_cumulative_x128: uint160 = convert(
+                convert(before_or_at.seconds_per_liquidity_cumulative_x128, uint256) + seconds_per_liquidity_delta,
+                uint160
+            )
+            
+            return tick_cumulative, seconds_per_liquidity_cumulative_x128
+        else:
+            # For real observations, interpolate between the points
+            tick_delta: int56 = at_or_after.tick_cumulative - before_or_at.tick_cumulative
+            tick_cumulative: int56 = before_or_at.tick_cumulative + (tick_delta * convert(target_delta, int56)) // convert(observation_time_delta, int56)
+            
+            # Convert to uint256 for higher precision arithmetic
+            before_spl: uint256 = convert(before_or_at.seconds_per_liquidity_cumulative_x128, uint256)
+            after_spl: uint256 = convert(at_or_after.seconds_per_liquidity_cumulative_x128, uint256)
+            
+            print("Interpolation - before_spl:", before_spl)
+            print("Interpolation - after_spl:", after_spl)
+            
+            # Calculate the delta between observations
+            spl_delta: uint256 = after_spl - before_spl
+            print("Interpolation - spl_delta:", spl_delta)
+            
+            # Scale up target_delta by 2^128 for precision
+            target_delta_scaled: uint256 = convert(target_delta, uint256) << 128
+            time_delta_scaled: uint256 = convert(observation_time_delta, uint256) << 128
+            
+            # First multiply spl_delta by target_delta_scaled
+            intermediate: uint256 = spl_delta * target_delta_scaled
+            print("Interpolation - intermediate:", intermediate)
+            
+            # Then divide by time_delta_scaled
+            interpolated_delta: uint256 = intermediate // time_delta_scaled
+            print("Interpolation - interpolated_delta:", interpolated_delta)
+            
+            # Add to the base value
+            result: uint256 = before_spl + interpolated_delta
+            print("Interpolation - result:", result)
+            
+            return tick_cumulative, convert(result, uint160)
+            
+# --- External Functions ---
+@external
+def initialize(params: InitializeParams):
+    """
+    @notice Initialize the oracle with the first observation
+    @param params The initialization parameters
+    """
+    assert self.cardinality == 0, "already initialized"
+    
+    # Set initial state
+    self.time = params.time
+    self.tick = params.tick
+    self.liquidity = params.liquidity
+    
+    # Create and store first observation
+    new_observation: Observation = Observation(
+        block_timestamp=params.time,
+        tick=params.tick,  # Store the initial tick
+        tick_cumulative=0,
+        seconds_per_liquidity_cumulative_x128=0,
+        initialized=True
+    )
+    
+    self.observations[0] = new_observation
+    self.cardinality = 1
+    self.cardinality_next = 1
+    
+    # Log the initialization
+    log ObservationUpdate(
+        new_observation.block_timestamp,
+        new_observation.tick_cumulative,
+        new_observation.seconds_per_liquidity_cumulative_x128,
+        new_observation.tick,
+        new_observation.initialized
+    )
+
+@external
+def advance_time(by: uint32):
+    """
+    @notice Advance the oracle time by a specified amount
+    @param by The amount of time to advance by
+    """
+    self.time = unsafe_add(self.time, by)
+
+@external
+def update(params: UpdateParams):
+    """
+    @notice Update the oracle with new observations
+    @param params The update parameters
+    """
+    self.time = unsafe_add(self.time, params.advance_time_by)
+    old_index: uint16 = self.index
+    new_observation: Observation = empty(Observation)
+    next_index: uint16 = 0
+    new_cardinality: uint16 = 0
+    new_observation, next_index, new_cardinality = self._write(
+        old_index,
+        self.time,
+        params.tick,  # Pass the new tick
+        params.liquidity,
+        self.cardinality,
+        self.cardinality_next
+    )
+    self.index = next_index
+    self.cardinality = new_cardinality
+    self.tick = params.tick
+    self.liquidity = params.liquidity
+
+@external
+def batch_update(params: DynArray[UpdateParams, 300]):
+    """
+    @notice Update the oracle with multiple observations in a batch
+    @param params Array of update parameters
+    """
+    _tick: int24 = self.tick
+    _liquidity: uint128 = self.liquidity
+    _index: uint16 = self.index
+    _cardinality: uint16 = self.cardinality
+    _cardinality_next: uint16 = self.cardinality_next
+    _time: uint32 = self.time
+    params_length: uint256 = len(params)
+
+    for i: uint256 in range(300):
+        if i >= params_length:
+            break
+        _time = unsafe_add(_time, params[i].advance_time_by)
+        new_observation: Observation = empty(Observation)
+        new_observation, _index, _cardinality = self._write(
+            _index,
+            _time,
+            _tick,
+            _liquidity,
+            _cardinality,
+            _cardinality_next
+        )
+        _tick = params[i].tick
+        _liquidity = params[i].liquidity
+
+    self.tick = _tick
+    self.liquidity = _liquidity
+    self.index = _index
+    self.cardinality = _cardinality
+    self.time = _time
+
+@external
+def grow(_cardinality_next: uint16):
+    """
+    @notice Grow the oracle's observation array to a larger size
+    @param _cardinality_next The new desired size of the array
+    """
+    self.cardinality_next = self._grow(self.cardinality_next, _cardinality_next)
+
+@external
+@view
+def observe(seconds_agos: DynArray[uint32, 256]) -> (DynArray[int56, 256], DynArray[uint160, 256]):
+    """
+    @notice Get observations from specified seconds ago
+    @param seconds_agos Array of seconds ago to query
+    @return Arrays of tick cumulatives and seconds per liquidity cumulatives
+    """
+    assert self.cardinality > 0, "oracle cardinality cannot be zero"
+    tick_cumulatives: DynArray[int56, 256] = []
+    seconds_per_liquidity_cumulative_x128s: DynArray[uint160, 256] = []
+    
+    seconds_agos_length: uint256 = len(seconds_agos)
+    
+    for i: uint256 in range(256):
+        if i >= seconds_agos_length:
+            break
+            
+        tick_cumulative: int56 = 0
+        seconds_per_liquidity_cumulative_x128: uint160 = 0
+        tick_cumulative, seconds_per_liquidity_cumulative_x128 = self._observe_single(
+            self.time,
+            seconds_agos[i],
+            self.tick,
+            self.index,
+            self.liquidity,
+            self.cardinality
+        )
+        tick_cumulatives.append(tick_cumulative)
+        seconds_per_liquidity_cumulative_x128s.append(seconds_per_liquidity_cumulative_x128)
+
+    return tick_cumulatives, seconds_per_liquidity_cumulative_x128s
+
+@external
+@view
+def get_gas_cost_of_observe(seconds_agos: DynArray[uint32, 256]) -> uint256:
+    """
+    @notice Calculate the gas cost of an observe operation
+    @param seconds_agos Array of seconds ago to query
+    @return The gas cost
+    """
+    gas_before: uint256 = msg.gas
+    
+    # Implement observation logic directly instead of calling self.observe
+    tick_cumulatives: DynArray[int56, 256] = []
+    seconds_per_liquidity_cumulative_x128s: DynArray[uint160, 256] = []
+    
+    seconds_agos_length: uint256 = len(seconds_agos)
+    
+    for i: uint256 in range(256):
+        if i >= seconds_agos_length:
+            break
+            
+        tick_cumulative: int56 = 0
+        seconds_per_liquidity_cumulative_x128: uint160 = 0
+        tick_cumulative, seconds_per_liquidity_cumulative_x128 = self._observe_single(
+            self.time,
+            seconds_agos[i],
+            self.tick,
+            self.index,
+            self.liquidity,
+            self.cardinality
+        )
+        tick_cumulatives.append(tick_cumulative)
+        seconds_per_liquidity_cumulative_x128s.append(seconds_per_liquidity_cumulative_x128)
+    
+    return unsafe_sub(gas_before, msg.gas)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -46,7 +46,9 @@ def system_addresses(accounts):
                         'lp_rewards': accounts[26].address,
                         'multisig': accounts[27].address,
                         'price_aggregator': accounts[28].address,
-                        'tellor_caller': accounts[29].address
+                        'tellor_caller': accounts[29].address,
+                        'oracle': accounts[30].address,
+                        'oracle_full': accounts[31].address
                         }
     return system_addresses
 
@@ -102,6 +104,12 @@ def system(owner, alice, bob, system_addresses, project):
     price_aggregator = boa.load_partial('tests/chainlink.vy').\
             deploy(18, 1, "eth/usd feed", boa.env.evm.patch.timestamp, 2900 * 10**18,
                    override_address=system_addresses['price_aggregator'])
+            
+    oracle = boa.load_partial('contracts/oracle.vy').\
+            deploy(override_address=system_addresses['oracle'])
+
+    oracle_full = boa.load_partial('contracts/oracle_full.vy').\
+            deploy(override_address=system_addresses['oracle_full'])
 
     lusd_token = boa.load_partial('contracts/lusd_token.vy').\
             deploy(system_addresses['trove_manager'],
@@ -173,9 +181,11 @@ def system(owner, alice, bob, system_addresses, project):
             'default_pool': default_pool,
             'gas_pool': gas_pool,
             'price_aggregator': price_aggregator,
-            'tellor_caller': tellor_caller
+            'tellor_caller': tellor_caller,
+            'oracle': oracle,
+            'oracle_full': oracle_full
             }
 
 @pytest.fixture
 def frontend(accounts):
-    return accounts[30]
+    return accounts[32]

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,0 +1,728 @@
+import ape
+import pytest
+import sys
+from pathlib import Path
+import boa
+from fixtures import system, owner, alice, bob, charlie, frontend, system_addresses
+from typing import Tuple, List
+from hypothesis import given, HealthCheck, settings
+from hypothesis import strategies as st
+
+
+class TestOracle:
+
+    @staticmethod
+    def observe_single(oracle, seconds_ago):
+        """
+        Helper function to get a single observation from the oracle
+
+        Args:
+            oracle: The initialized oracle contract instance
+            seconds_ago (int): Number of seconds ago to get the observation from
+
+        Returns:
+            tuple: (tick_cumulative, seconds_per_liquidity_cumulative)
+        """
+        seconds_agos = [seconds_ago]
+        tick_cumulatives, seconds_per_liquidity_cumulatives = oracle.observe(seconds_agos)
+        return tick_cumulatives[0], seconds_per_liquidity_cumulatives[0]
+
+    @staticmethod
+    def assert_observation(oracle, index, expected):
+        """
+        Helper function to assert that an observation matches expected values
+
+        Args:
+            oracle: The oracle contract instance
+            idx: The index of the observation to check
+            expected: Dict containing expected values with keys:
+                - block_timestamp (uint32)
+                - tick_cumulative (int56) 
+                - seconds_per_liquidity_cumulative_x128 (uint160)
+                - tick (int24)
+                - initialized (bool)
+        """
+        observation = oracle.observations(index)
+        # print(observation)
+        assert observation[0] == expected['block_timestamp'], "block_timestamp mismatch"
+        assert observation[1] == expected['tick'], "tick mismatch" 
+        assert observation[2] == expected['tick_cumulative'], "tick_cumulative mismatch"
+        assert observation[3] == expected['seconds_per_liquidity_cumulative_x128'], "seconds_per_liquidity_cumulative_x128 mismatch"
+        assert observation[4] == expected['initialized'], "initialized mismatch" 
+        
+    @staticmethod
+    def setup_oracle_with_many_observations(oracle, starting_time):
+        """
+        Sets up an oracle with multiple observations over time.
+    
+        Args:
+            oracle: The oracle contract instance
+            starting_time: Initial timestamp for the oracle
+        """
+        # Initialize oracle with starting parameters
+        oracle.initialize((starting_time, -5, 5))
+        oracle.grow(5)
+        oracle.update((3, 1, 2))
+        oracle.update((2, -6, 4))
+        oracle.update((4, -2, 4))
+        oracle.update((1, -2, 9))
+        oracle.update((3, 4, 2))
+        oracle.update((6, 6, 7))
+        return oracle
+    
+    @staticmethod
+    def setup_full_oracle(oracle):
+        """
+        Sets up an oracle with 65535 observations.
+        """
+        
+        oracle.initialize((
+            1601906400,  # Monday, October 5, 2020 9:00:00 AM GMT-05:00
+            0,  # initial liquidity
+            0  # initial tick
+        ))
+        
+        # Grow to full size first
+        BATCH_SIZE = 300
+        GROW_BATCH_SIZE = 3000
+        TOTAL_SIZE = 65535
+        
+        # First grow to full capacity
+        cardinality_next = oracle.cardinality_next()
+        while cardinality_next < TOTAL_SIZE:
+            if (cardinality_next + GROW_BATCH_SIZE < TOTAL_SIZE):
+                grow_to = cardinality_next + GROW_BATCH_SIZE
+            else:
+                grow_to = TOTAL_SIZE
+            oracle.grow(grow_to)
+            print(f'grow_to: {grow_to}')
+            cardinality_next = grow_to
+            
+        # Only write complete batches of 300 observations
+        # This will write exactly 218 batches (218 * 300 = 65400) + 1 batch (300)
+        # The index will end up at 65700 % 65535 = 165
+        num_complete_batches = TOTAL_SIZE // BATCH_SIZE  # This is 218
+        MAX_UINT128 = 2**128 - 1
+        # 300
+        for i in range(0, (num_complete_batches + 1) * BATCH_SIZE, BATCH_SIZE):
+            batch = []
+            for j in range(BATCH_SIZE):
+                batch.append((
+                    13,  # advanceTimeBy: 13 seconds
+                    -(i + j),  # tick: -i - j
+                    i + j  # liquidity: uint128(int128(i) + int128(j))
+                ))
+            oracle.batch_update(batch)
+            print(f"After batch {i//BATCH_SIZE}: index={oracle.index()}, cardinality={oracle.cardinality()}")
+        return oracle
+
+    @pytest.fixture
+    def initialized_oracle(self, system):
+        oracle = system['oracle']
+        time = 0  # uint32
+        tick = 0  # int24
+        liquidity = 0  # uint128
+        params = (time, tick, liquidity)
+        oracle.initialize(params)
+        return oracle
+
+    @pytest.fixture
+    def initialized_oracle_with_many_observations(self, system):
+        oracle = system['oracle']
+        time = 0  # uint32
+        tick = 0  # int24
+        liquidity = 0  # uint128
+        params = (time, tick, liquidity)
+        oracle.initialize((time, tick, liquidity))
+        oracle.grow(5)
+        oracle.update((1, 2, 5))
+        oracle.update((5, -1, 8))
+        oracle.update((3, 2, 3))
+        oracle.update((6, 3, 2))
+        
+        return oracle
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_initialize(self, initialized_oracle):
+        assert initialized_oracle.index() == 0
+        assert initialized_oracle.cardinality() == 1
+        assert initialized_oracle.cardinality_next() == 1
+        print(initialized_oracle.observations(0))
+        self.assert_observation(initialized_oracle, 0, {'block_timestamp': 0, 'tick': 0, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 0, 'initialized': True })
+       
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_grow(self, initialized_oracle):
+        initialized_oracle.grow(5)
+        assert initialized_oracle.index() == 0
+        assert initialized_oracle.cardinality() == 1
+        assert initialized_oracle.cardinality_next() == 5
+
+        # Check first slot
+        self.assert_observation(initialized_oracle, 0, {'block_timestamp': 0, 'tick': 0, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 0, 'initialized': True})
+        
+        # Check additional slots
+        for i in range(1, 5):
+            self.assert_observation(initialized_oracle, i, {'block_timestamp': 1, 'tick': 0, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 0, 'initialized': False})
+
+        # Test noop if already at size
+        initialized_oracle.grow(3)
+        
+        assert initialized_oracle.index() == 0
+        assert initialized_oracle.cardinality() == 1
+        assert initialized_oracle.cardinality_next() == 5
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_grow_after_wrap(self, initialized_oracle):
+        initialized_oracle.grow(2)
+        assert initialized_oracle.index() == 0
+        initialized_oracle.update((2, 1, 1))
+        # index is now 1
+        assert initialized_oracle.index() == 1
+        initialized_oracle.update((2, 1, 1))
+        # index is now 0 again
+        assert initialized_oracle.index() == 0
+        initialized_oracle.grow(3)
+        assert initialized_oracle.index() == 0
+        assert initialized_oracle.cardinality() == 2
+        assert initialized_oracle.cardinality_next() == 3
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_grow_1_slot(self, initialized_oracle):
+        gas_before = boa.env.get_gas_used()
+        initialized_oracle.grow(2)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used grow 1 slot: {gas_used}')
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_grow_10_slots(self, initialized_oracle):
+        gas_before = boa.env.get_gas_used()
+        initialized_oracle.grow(11)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used grow 10 slots: {gas_used}')
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_grow_1_slot_cardinality_greater(self, initialized_oracle):
+        initialized_oracle.grow(2)
+        gas_before = boa.env.get_gas_used()
+        initialized_oracle.grow(3)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used grow 1 slot cardinality greater: {gas_used}')
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_grow_10_slots_cardinality_greater(self, initialized_oracle):
+        initialized_oracle.grow(2)
+        gas_before = boa.env.get_gas_used()
+        initialized_oracle.grow(12)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used grow 10 slots cardinality greater: {gas_used}')
+        
+    # # @pytest.mark.skip(reason="temporarily disabled")
+    def test_write(self, initialized_oracle):
+        initialized_oracle.update((1, 2, 5))
+        assert initialized_oracle.index() == 0
+        self.assert_observation(initialized_oracle, 0, {'block_timestamp': 1, 'tick': 2, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 340282366920938463463374607431768211456, 'initialized': True})
+        initialized_oracle.update((5, -1, 8)) 
+        assert initialized_oracle.index() == 0
+        self.assert_observation(initialized_oracle, 0, {'block_timestamp': 6, 'tick': -1, 'tick_cumulative': 10, 'seconds_per_liquidity_cumulative_x128': 680564733841876926926749214863536422912, 'initialized': True})
+        initialized_oracle.update((3, 2, 3)) 
+        assert initialized_oracle.index() == 0
+        self.assert_observation(initialized_oracle, 0, {'block_timestamp': 9, 'tick': 2, 'tick_cumulative': 7, 'seconds_per_liquidity_cumulative_x128': 808170621437228850725514692650449502208, 'initialized': True})
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_write_adds_nothing_if_time_unchanged(self, initialized_oracle):
+        initialized_oracle.grow(2)
+        initialized_oracle.update((1, 3, 2))
+        assert initialized_oracle.index() == 1
+        initialized_oracle.update((0, -5, 9))
+        assert initialized_oracle.index() == 1
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_write_time_changed(self, initialized_oracle):
+        initialized_oracle.grow(3)
+        initialized_oracle.update((6, 3, 2))
+        assert initialized_oracle.index() == 1
+        initialized_oracle.update((4, -5, 9))
+        assert initialized_oracle.index() == 2
+        self.assert_observation(initialized_oracle, 1, {'block_timestamp': 6, 'tick': 3, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 2041694201525630780780247644590609268736, 'initialized': True})
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_write_grows_cardinality_writing_past(self, initialized_oracle):
+        initialized_oracle.grow(2)
+        initialized_oracle.grow(4)
+        assert initialized_oracle.cardinality() == 1
+        initialized_oracle.update((3, 5, 6))
+        assert initialized_oracle.cardinality() == 4
+        initialized_oracle.update((4, 6, 4))
+        assert initialized_oracle.cardinality() == 4
+        assert initialized_oracle.index() == 2
+        self.assert_observation(initialized_oracle, 2, {'block_timestamp': 7,'tick': 6, 'tick_cumulative': 20, 'seconds_per_liquidity_cumulative_x128': 1247702012043441032699040227249816775338, 'initialized': True})
+
+    # @pytest.mark.skip(reason="temporarily disabled")   
+    def test_write_wraps_around(self, initialized_oracle):
+        initialized_oracle.grow(3)
+        initialized_oracle.update((3, 1, 2))
+        initialized_oracle.update((4, 2, 3))
+        initialized_oracle.update((5, 3, 4))
+        assert initialized_oracle.index() == 0
+        self.assert_observation(initialized_oracle, 0, {'block_timestamp': 12, 'tick': 3, 'tick_cumulative': 14, 'seconds_per_liquidity_cumulative_x128': 2268549112806256423089164049545121409706, 'initialized': True})
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_write_accumulates_liquidity(self, initialized_oracle):
+        initialized_oracle.grow(4)
+        initialized_oracle.update((3, 3, 2))
+        initialized_oracle.update((4, -7, 6))
+        initialized_oracle.update((5, -2, 4))
+        assert initialized_oracle.index() == 3
+        self.assert_observation(initialized_oracle, 1, {'block_timestamp': 3, 'tick': 3, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 1020847100762815390390123822295304634368, 'initialized': True})
+        self.assert_observation(initialized_oracle, 2, {'block_timestamp': 7, 'tick': -7, 'tick_cumulative': 12, 'seconds_per_liquidity_cumulative_x128': 1701411834604692317316873037158841057280, 'initialized': True})
+        self.assert_observation(initialized_oracle, 3, {'block_timestamp': 12, 'tick': -2, 'tick_cumulative': -23, 'seconds_per_liquidity_cumulative_x128': 1984980473705474370203018543351981233493, 'initialized': True})
+        self.assert_observation(initialized_oracle, 4, {'block_timestamp': 0, 'tick': 0, 'tick_cumulative': 0, 'seconds_per_liquidity_cumulative_x128': 0, 'initialized': False})
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_observe_fails_before_initialize(self, system):
+        oracle = system['oracle']
+        with pytest.raises(Exception) as excinfo:
+            oracle.observe([0])
+        assert "<oracle cardinality cannot be zero>" in str(excinfo.value)
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_observe_fails_if_older_does_not_exist(self, system):
+        oracle = system['oracle']
+        oracle.initialize((4, 2, 5))
+        with pytest.raises(Exception) as excinfo:
+            oracle.observe([1])
+        assert "<target predates oldest observation>" in str(excinfo.value)
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_does_not_fail_across_overflow_boundary(self, system):
+        oracle = system['oracle']
+        oracle.initialize((2**32 - 1, 2, 4))
+        oracle.advance_time(2)
+        result = self.observe_single(oracle, 1)
+        assert result[0] == 2
+        assert result[1] == 85070591730234615865843651857942052864
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_interpolation_max_liquidity(self, system):
+        oracle = system['oracle']
+        oracle.initialize((0, 0, 2**128 - 1))
+        oracle.grow(2)
+        oracle.update((13, 0, 0))
+        result = self.observe_single(oracle, 0)
+        assert result[1] == 13
+        result = self.observe_single(oracle, 6)
+        assert result[1] == 7
+        result = self.observe_single(oracle, 12)
+        assert result[1] == 1
+        result = self.observe_single(oracle, 13)
+        assert result[1] == 0
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_interpolates_same_0_and_1_liquidity(self, system):
+        oracle = system['oracle']
+        oracle.initialize((0, 0, 1)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((13, 0, 0))
+        result = self.observe_single(oracle, 0)
+        assert result[1] == 13 << 128
+        result = self.observe_single(oracle, 6)
+        assert result[1] == 7 << 128
+        result = self.observe_single(oracle, 12)
+        assert result[1] == 1 << 128
+        result = self.observe_single(oracle, 13)
+        assert result[1] == 0
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_interpolates_across_chunk_boundaries(self, system):
+        oracle = system['oracle']
+        oracle.initialize((0, 0, 0)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((2 ** 32 - 6, 0, 0))
+        result = self.observe_single(oracle, 0)
+        assert result[1] == (2 ** 32 - 6) << 128
+        oracle.update((13, 0, 0))
+        result = self.observe_single(oracle, 0)
+        assert result[1] == 7 << 128
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_single_observation_at_current_time(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, 2, 4)) # time, tick, liquidity
+        result = self.observe_single(oracle, 0)
+        assert result[0] == 0
+        assert result[1] == 0
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_single_observation_in_recent_past(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, 2, 4)) # time, tick, liquidity
+        oracle.advance_time(3)
+        with pytest.raises(Exception) as excinfo:
+            self.observe_single(oracle, 4)
+        assert "<target predates oldest observation>" in str(excinfo.value)
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_single_observation_seconds_ago(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, 2, 4)) # time, tick, liquidity
+        oracle.advance_time(3)
+        result = self.observe_single(oracle, 3)
+        assert result[0] == 0
+        assert result[1] == 0
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_single_observation_in_past_counterfactual_in_past(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, 2, 4)) # time, tick, liquidity
+        oracle.advance_time(3)
+        result = self.observe_single(oracle, 1)
+        assert result[0] == 4
+        assert result[1] == 170141183460469231731687303715884105728
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_single_observation_in_past_counterfactual_now(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, 2, 4)) # time, tick, liquidity
+        oracle.advance_time(3)
+        result = self.observe_single(oracle, 0)
+        assert result[0] == 6
+        assert result[1] == 255211775190703847597530955573826158592
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_chronological_zero_seconds_ago_exact(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        result = self.observe_single(oracle, 0)
+        assert result[0] == -20
+        assert result[1] == 272225893536750770770699685945414569164
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_chronological_zero_seconds_ago_counterfactual(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.advance_time(7)
+        result = self.observe_single(oracle, 0)
+        assert result[0] == -13
+        assert result[1] == 1463214177760035392892510811956603309260
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_chronological_seconds_ago_exactly_first_observation(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.advance_time(7)
+        result = self.observe_single(oracle, 11)
+        assert result[0] == 0
+        assert result[1] == 0
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_chronological_seconds_ago_between(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.advance_time(7)
+        result = self.observe_single(oracle, 9)
+        assert result[0] == -10
+        assert result[1] == 136112946768375385385349842972707284582
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_reverse_order_zero_seconds_ago_exact(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.update((3, -5, 4))
+        result = self.observe_single(oracle, 0)
+        assert result[0] == -17
+        assert result[1] == 782649443918158465965761597093066886348
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_reverse_order_zero_seconds_ago_counterfactual(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.update((3, -5, 4))
+        oracle.advance_time(7)
+        result = self.observe_single(oracle, 0)
+        assert result[0] == -52
+        assert result[1] == 1378143586029800777026667160098661256396
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_reverse_order_seconds_ago_exactly_on_first_observation(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.update((3, -5, 4))
+        oracle.advance_time(7)
+        result = self.observe_single(oracle, 10)
+        assert result[0] == -20
+        assert result[1] == 272225893536750770770699685945414569164
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_two_observations_reverse_order_seconds_ago_between(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.grow(2)
+        oracle.update((4, 1, 2))
+        oracle.update((3, -5, 4))
+        oracle.advance_time(7)
+        result = self.observe_single(oracle, 9)
+        assert result[0] == -19
+        assert result[1] == 442367076997220002502386989661298674892
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_can_fetch_multiple_observations(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, 2, 2 ** 15)) # time, tick, liquidity
+        oracle.grow(4)
+        oracle.update((13, 6, 2 ** 12))
+        oracle.advance_time(5)
+        seconds_agos = [0, 3, 8, 13, 15, 18]
+        tick_cumulatives, seconds_per_liquidity_cumulatives = oracle.observe(seconds_agos)
+        assert tick_cumulatives[0] == 56
+        assert tick_cumulatives[1] == 38
+        assert tick_cumulatives[2] == 20
+        assert tick_cumulatives[3] == 10
+        assert tick_cumulatives[4] == 6
+        assert tick_cumulatives[5] == 0
+        assert seconds_per_liquidity_cumulatives[0] == 550383467004691728624232610897330176
+        assert seconds_per_liquidity_cumulatives[1] == 301153217795020002454768787094765568
+        assert seconds_per_liquidity_cumulatives[2] == 103845937170696552570609926584401920
+        assert seconds_per_liquidity_cumulatives[3] == 51922968585348276285304963292200960
+        assert seconds_per_liquidity_cumulatives[4] == 31153781151208965771182977975320576
+        assert seconds_per_liquidity_cumulatives[5] == 0
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_since_most_recent(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5)) # time, tick, liquidity
+        oracle.advance_time(2)
+        gas_before = boa.env.get_gas_used()
+        self.observe_single(oracle, 1)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe since most recent: {gas_used}')
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_current_time(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5))
+        gas_before = boa.env.get_gas_used()
+        self.observe_single(oracle, 0)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe current time: {gas_used}')
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_current_time_counterfactual(self, system):
+        oracle = system['oracle']
+        oracle.initialize((5, -5, 5))
+        oracle.advance_time(5)
+        gas_before = boa.env.get_gas_used()
+        self.observe_single(oracle, 0)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe current time counterfactual: {gas_used}')
+       
+    # @pytest.mark.skip(reason="temporarily disabled") 
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_simple_reads(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        assert oracle.index() == 1
+        assert oracle.cardinality() == 5
+        assert oracle.cardinality_next() == 5
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_latest_observation_same_time_as_latest(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 0)
+        assert tick_cumulative == -21
+        assert seconds_per_liquidity_cumulative_x128 == 2104079302127802832415199655953100107502
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_latest_observation_5_seconds_after_latest(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        oracle.advance_time(5)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 5)
+        assert tick_cumulative == -21
+        assert seconds_per_liquidity_cumulative_x128 == 2104079302127802832415199655953100107502
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_current_observation_5_seconds_after_latest(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        oracle.advance_time(5)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 0)
+        assert tick_cumulative == 9
+        assert seconds_per_liquidity_cumulative_x128 == 2347138135642758877746181518404363115684
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_between_latest_observation_at_latest(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 3)
+        assert tick_cumulative == -33
+        assert seconds_per_liquidity_cumulative_x128 == 1593655751746395137220137744805447790318
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_between_latest_observation_after_latest(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        oracle.advance_time(5)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 8)
+        assert tick_cumulative == -33
+        assert seconds_per_liquidity_cumulative_x128 == 1593655751746395137220137744805447790318
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_older_than_oldest_reverts(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        seconds_ago = 15
+        
+        with pytest.raises(Exception) as excinfo:
+            oracle.observe([seconds_ago])
+        assert "<target predates oldest observation>" in str(excinfo.value)
+        
+        oracle.advance_time(5)
+        seconds_agos = 20
+        
+        with pytest.raises(Exception) as excinfo:
+            oracle.observe([seconds_agos])
+        assert "<target predates oldest observation>" in str(excinfo.value)
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_oldest(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 14)
+        assert tick_cumulative == -13
+        assert seconds_per_liquidity_cumulative_x128 == 544451787073501541541399371890829138329
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_oldest_after_time(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        oracle.advance_time(6)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 20)
+        assert tick_cumulative == -13
+        assert seconds_per_liquidity_cumulative_x128 == 544451787073501541541399371890829138329
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @given(starting_time=st.integers(min_value=0, max_value=2**32 - 1))
+    def test_many_observations_fetch_many_values(self, system, starting_time):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, starting_time)
+        oracle.advance_time(6)
+        seconds_agos = [20, 17, 13, 10, 5, 1, 0]
+        (tick_cumulatives, seconds_per_liquidity_cumulatives) = oracle.observe(seconds_agos)
+        assert tick_cumulatives[0] == -13
+        assert seconds_per_liquidity_cumulatives[0] == 544451787073501541541399371890829138329
+        assert tick_cumulatives[1] == -31
+        assert seconds_per_liquidity_cumulatives[1] == 799663562264205389138930327464655296921
+        assert tick_cumulatives[2] == -43
+        assert seconds_per_liquidity_cumulatives[2] == 1045423049484883168306923099498710116305
+        assert tick_cumulatives[3] == -37
+        assert seconds_per_liquidity_cumulatives[3] == 1423514568285925905488450441089563684590
+        assert tick_cumulatives[4] == -15
+        assert seconds_per_liquidity_cumulatives[4] == 2152691068830794041481396028443352709138
+        assert tick_cumulatives[5] == 9
+        assert seconds_per_liquidity_cumulatives[5] == 2347138135642758877746181518404363115684
+        assert tick_cumulatives[6] == 15
+        assert seconds_per_liquidity_cumulatives[6] == 2395749902345750086812377890894615717321
+   
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_last_20_seconds(self, system):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, 0)
+        oracle.advance_time(6);
+        seconds_agos = [20 - i for i in range(20)]
+        gas_before = boa.env.get_gas_used()
+        oracle.observe(seconds_agos)
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe last 20 seconds: {gas_used}')
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_latest_equal(self, system):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, 5)
+        gas_before = boa.env.get_gas_used()
+        oracle.observe([0])
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe latest equal: {gas_used}')
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_latest_transform(self, system):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, 5)
+        oracle.advance_time(5)
+        gas_before = boa.env.get_gas_used()
+        oracle.observe([0])
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe latest transform: {gas_used}')
+      
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_oldest(self, system):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, 5)
+        gas_before = boa.env.get_gas_used()
+        oracle.observe([14])
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe oldest: {gas_used}')
+        
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_between_oldest_and_oldest_plus_one(self, system):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, 5)
+        gas_before = boa.env.get_gas_used()
+        oracle.observe([13])
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe between oldest and oldest plus one: {gas_used}')
+    
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_gas_cost_of_observe_middle(self, system):
+        base_oracle = system['oracle']
+        oracle = self.setup_oracle_with_many_observations(base_oracle, 5)
+        gas_before = boa.env.get_gas_used()
+        oracle.observe([5])
+        gas_after = boa.env.get_gas_used()
+        gas_used = gas_after - gas_before
+        print(f'Gas used observe middle: {gas_used}')

--- a/tests/test_oracle_full.py
+++ b/tests/test_oracle_full.py
@@ -1,0 +1,178 @@
+import ape
+import pytest
+import sys
+from pathlib import Path
+import boa
+from fixtures import system, owner, alice, bob, charlie, frontend, system_addresses
+from dataclasses import dataclass
+from typing import Tuple, List
+from hypothesis import given, HealthCheck, settings
+from hypothesis import strategies as st
+
+
+class TestOracle:
+    
+    @staticmethod
+    def observe_single(oracle, seconds_ago):
+        """
+        Helper function to get a single observation from the oracle
+
+        Args:
+            oracle: The initialized oracle contract instance
+            seconds_ago (int): Number of seconds ago to get the observation from
+
+        Returns:
+            tuple: (tick_cumulative, seconds_per_liquidity_cumulative)
+        """
+        seconds_agos = [seconds_ago]
+        tick_cumulatives, seconds_per_liquidity_cumulatives = oracle.observe(seconds_agos)
+        return tick_cumulatives[0], seconds_per_liquidity_cumulatives[0]
+
+    @staticmethod
+    def setup_full_oracle(oracle):
+        """
+        Sets up an oracle with 65535 observations.
+        """
+        
+        oracle.initialize((
+            1601906400,  # Monday, October 5, 2020 9:00:00 AM GMT-05:00
+            0,  # initial liquidity
+            0  # initial tick
+        ))
+        
+        # Grow to full size first
+        BATCH_SIZE = 300
+        GROW_BATCH_SIZE = 3000
+        TOTAL_SIZE = 65535
+        
+        # First grow to full capacity
+        cardinality_next = oracle.cardinality_next()
+        while cardinality_next < TOTAL_SIZE:
+            if (cardinality_next + GROW_BATCH_SIZE < TOTAL_SIZE):
+                grow_to = cardinality_next + GROW_BATCH_SIZE
+            else:
+                grow_to = TOTAL_SIZE
+            oracle.grow(grow_to)
+            print(f'grow_to: {grow_to}')
+            cardinality_next = grow_to
+            
+        # Only write complete batches of 300 observations
+        # This will write exactly 218 batches (218 * 300 = 65400) + 1 batch (300)
+        # The index will end up at 65700 % 65535 = 165
+        num_complete_batches = TOTAL_SIZE // BATCH_SIZE  # This is 218
+        MAX_UINT128 = 2**128 - 1
+        # 300
+        for i in range(0, (num_complete_batches + 1) * BATCH_SIZE, BATCH_SIZE):
+            batch = []
+            for j in range(BATCH_SIZE):
+                batch.append((
+                    13,  # advanceTimeBy: 13 seconds
+                    -(i + j),  # tick: -i - j
+                    i + j  # liquidity: uint128(int128(i) + int128(j))
+                ))
+            oracle.batch_update(batch)
+            print(f"After batch {i//BATCH_SIZE}: index={oracle.index()}, cardinality={oracle.cardinality()}")
+        return oracle
+
+    # @pytest.mark.skip(reason="temporarily disabled")
+    def test_full_oracle(self, system):
+        base_oracle = system['oracle_full']
+        oracle = self.setup_full_oracle(base_oracle)
+        
+        assert oracle.cardinality_next() == 65535
+        assert oracle.cardinality() == 65535
+        assert oracle.index() == 165
+        
+        tolerance_percentage = 0.005  # 0.005% tolerance
+        
+        # can observe into the ordered portion with exact seconds ago
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 100 * 13)
+        expected_cumulative = -27970560813
+        tolerance = abs(expected_cumulative * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_cumulative) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_cumulative} by {abs(tick_cumulative - expected_cumulative) / abs(expected_cumulative) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_cumulative = 60465049086512033878831623038233202591033
+        tolerance_percentage = 0.005  # 0.005% tolerance
+        tolerance = abs(expected_cumulative * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_cumulative) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_cumulative} by {abs(seconds_per_liquidity_cumulative_x128 - expected_cumulative) / abs(expected_cumulative) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe into the ordered portion with unexact seconds ago
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 100 * 13 + 5)
+        expected_tick = -27970232823
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 60465023149565257990964350912969670793706
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe at exactly the latest observation
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 0)
+        expected_tick = -28055903863
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 60471787506468701386237800669810720099776
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe into the unordered portion of array at exact seconds ago
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 200 * 13)
+        expected_tick = -27885347763
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 60458300386499273141628780395875293027404
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe into the unordered portion of array at seconds ago between observations
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 200 * 13 + 5)
+        expected_tick = -27885020273
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 60458274409952896081377821330361274907140
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe the oldest observation
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 13 * 65534)
+        expected_tick = -175890
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 33974356747348039873972993881117400879779
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe at exactly the latest observation after some time passes
+        oracle.advance_time(5)
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 5)
+        expected_tick = -28055903863
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 60471787506468701386237800669810720099776
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe after the latest observation counterfactual
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 3)
+        expected_tick = -28056035261
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 60471797865298117996489508104462919730461
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        # can observe the oldest observation after time passes
+        (tick_cumulative, seconds_per_liquidity_cumulative_x128) = self.observe_single(oracle, 13 * 65534 + 5)
+        expected_tick = -175890
+        tolerance = abs(expected_tick * tolerance_percentage / 100)
+        assert abs(tick_cumulative - expected_tick) <= tolerance, f"Cumulative value {tick_cumulative} differs from expected {expected_tick} by {abs(tick_cumulative - expected_tick) / abs(expected_tick) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"
+
+        expected_spl = 33974356747348039873972993881117400879779
+        tolerance = abs(expected_spl * tolerance_percentage / 100)
+        assert abs(seconds_per_liquidity_cumulative_x128 - expected_spl) <= tolerance, f"Cumulative value {seconds_per_liquidity_cumulative_x128} differs from expected {expected_spl} by {abs(seconds_per_liquidity_cumulative_x128 - expected_spl) / abs(expected_spl) * 100:.4f}% (tolerance: ±{tolerance_percentage}%)"


### PR DESCRIPTION
This PR ports the following uni oracle lib functionality from solidity to vyper.

Original Solidity Code:

Oracle Lib: https://github.com/Uniswap/v4-periphery/blob/trunc-oracle/contracts/libraries/Oracle.sol
Oracle Implementation: https://github.com/Uniswap/v4-periphery/blob/trunc-oracle/test/shared/implementation/OracleImplementation.sol
Test Suite: https://github.com/Uniswap/v4-periphery/blob/trunc-oracle/test/Oracle.t.sol

The Vyper port is not written using a library pattern due to differences in how Solidity and Vyper pass arrays.

There are 2 versions of the Vyper oracle

1. oracle.vy
2. oracle_full.vy

The `oracle.vy` passes all of the base tests from the original solidity code but fails when expanding the oracle to production size (`65535` observations)

The `oracle_full.vy` fails to past some of the base tests but properly handles the large numbers in the production oracle test.

To run the tests

```
ape test tests/test_oracle.py -s

# and

ape test tests/test_oracle_full.py -s
```

These 2 implementations need to be reconciled into a single implementation that passes the entire test suite.

The `test_oracle_full.py` full test attains the same results as the solidity implementation within a tolerance of `0.005%`

The tolerance is required due to core differences in the languages (Solidity vs Vyper) for example:

1. Different rounding behavior in integer division between Solidity and Vyper
2. Order of operations and how each language handles intermediate values
3. Differences in type conversion and precision handling

The `test_oracle_full.py` maintains the same general requirements as the Solidity implementation such that we are:

1. Maintaining the Q128.128 fixed-point precision
2. Correctly handling the interpolation formula
3. Getting results that are very close to expected values
4. Not losing significant digits in the calculations

I think this is as close to exact the Vyper version can get to replicating the values from the Solidity version when accounting for the reasons above. 

